### PR TITLE
Add task-time pool reconciliation

### DIFF
--- a/airflow_pydantic/core/render/utils.py
+++ b/airflow_pydantic/core/render/utils.py
@@ -40,8 +40,7 @@ def _islambda(v):
     return isinstance(v, _LAMBDA_TYPE) and v.__name__ == "<lambda>"
 
 
-def _build_pool_callable(pool, airflow_major_version: int = 2) -> tuple[ast.ImportFrom, ast.Call]:
-    imports = []
+def _build_pool_callable(pool, airflow_major_version: int = 2) -> tuple[list[ast.ImportFrom], ast.AST]:
     if isinstance(pool, Pool):
         # Swap
         pool = pool.model_dump(exclude_unset=True)
@@ -63,77 +62,7 @@ def _build_pool_callable(pool, airflow_major_version: int = 2) -> tuple[ast.Impo
     else:
         raise TypeError(f"Unsupported type for pool: {type(pool)}. Expected Pool, AirflowPool, or str.")
 
-    # Replace the pool with the Pool class
-    if airflow_major_version == 2:
-        if len(pool.keys()) == 1:
-            imports.append(
-                ast.ImportFrom(
-                    module="airflow.models.pool",
-                    names=[ast.alias(name="Pool")],
-                    level=0,
-                )
-            )
-            # Replace the pool with the Pool class
-            return imports, ast.Attribute(
-                value=ast.Call(
-                    func=ast.Attribute(value=ast.Name(id="Pool", ctx=ast.Load()), attr="get_pool", ctx=ast.Load()),
-                    args=[ast.Constant(value=pool["pool"])],
-                    keywords=[],
-                ),
-                attr="pool",
-                ctx=ast.Load(),
-            )
-        imports.append(
-            ast.ImportFrom(
-                module="airflow.models.pool",
-                names=[ast.alias(name="Pool")],
-                level=0,
-            )
-        )
-        return imports, ast.Attribute(
-            value=ast.Call(
-                func=ast.Attribute(value=ast.Name(id="Pool", ctx=ast.Load()), attr="create_or_update_pool", ctx=ast.Load()),
-                args=[],
-                keywords=[
-                    ast.keyword(arg="name", value=ast.Constant(value=pool["pool"])),
-                    ast.keyword(arg="slots", value=ast.Constant(value=pool.get("slots", 128))),
-                    ast.keyword(arg="description", value=ast.Constant(value=pool.get("description", ""))),
-                    ast.keyword(arg="include_deferred", value=ast.Constant(value=pool.get("include_deferred", False))),
-                ],
-            ),
-            attr="pool",
-            ctx=ast.Load(),
-        )
-    # TODO just use it as a string literal in airflow 3 for now
     return [], ast.Constant(value=pool["pool"])
-    # imports.append(
-    #     ast.ImportFrom(
-    #         module="subprocess",
-    #         names=[ast.alias(name="check_call")],
-    #         level=0,
-    #     )
-    # )
-    # return imports, ast.Attribute(
-    #     value=ast.Call(
-    #         func=ast.Name(id="check_call", ctx=ast.Load()),
-    #         args=[
-    #             ast.List(
-    #                 elts=[
-    #                     ast.Constant(value="airflow"),
-    #                     ast.Constant(value="pools"),
-    #                     ast.Constant(value="set"),
-    #                     ast.Constant(value=pool["pool"]),
-    #                     ast.Constant(value=str(pool.get("slots", 128))),
-    #                     ast.Constant(value=pool.get("description", "")),
-    #                 ],
-    #                 ctx=ast.Load(),
-    #             )
-    #         ],
-    #         keywords=[],
-    #     ),
-    #     attr="pool",
-    #     ctx=ast.Load(),
-    # )
 
 
 def _build_param_callable(param, key, airflow_major_version: int = 2) -> tuple[list[ast.ImportFrom], ast.Call]:

--- a/airflow_pydantic/extras/balancer/__init__.py
+++ b/airflow_pydantic/extras/balancer/__init__.py
@@ -1,4 +1,5 @@
 from .balancer import *
 from .host import *
+from .pool_manager import *
 from .port import *
 from .query import *

--- a/airflow_pydantic/extras/balancer/_pool_runtime.py
+++ b/airflow_pydantic/extras/balancer/_pool_runtime.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+from importlib.metadata import version
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+POOL_RUNTIME_VERSION = 1
+
+
+def reconcile_pools(pool_plan: list[dict[str, Any]], backend: dict[str, Any]) -> list[str]:
+    kind = backend.get("kind", "auto")
+    if kind == "auto":
+        if backend.get("mwaa_environment_name"):
+            kind = "mwaa"
+        elif int(version("apache-airflow").split(".", 1)[0]) < 3:
+            kind = "airflow2"
+        else:
+            kind = "airflow3"
+
+    if kind == "airflow2":
+        actions = _reconcile_airflow2(pool_plan, backend)
+    elif kind == "airflow3":
+        actions = _reconcile_api(pool_plan, backend, _airflow3_request(backend))
+    elif kind == "mwaa":
+        actions = _reconcile_api(pool_plan, backend, _mwaa_request(backend))
+    else:
+        raise ValueError(f"Unsupported pool manager backend: {kind}")
+
+    for action in actions:
+        print(action)
+    return actions
+
+
+def _reconcile_airflow2(pool_plan: list[dict[str, Any]], backend: dict[str, Any]) -> list[str]:
+    from airflow.models.pool import Pool
+
+    actions = []
+    for desired in pool_plan:
+        try:
+            current = Pool.get_pool(desired["name"])
+        except Exception as error:  # Airflow versions expose different PoolNotFound classes.
+            if error.__class__.__name__ != "PoolNotFound":
+                raise
+            current = None
+
+        if current is None:
+            Pool.create_or_update_pool(
+                desired["name"],
+                desired["slots"],
+                desired["description"],
+                desired["include_deferred"],
+            )
+            actions.append(f"created {desired['name']}")
+            continue
+
+        values = _changes(current, desired, backend.get("override_pool_size", False))
+        if values:
+            Pool.create_or_update_pool(
+                desired["name"],
+                values.get("slots", current.slots),
+                values.get("description", current.description),
+                values.get("include_deferred", current.include_deferred),
+            )
+            actions.append(f"updated {desired['name']}: {', '.join(values)}")
+        else:
+            actions.append(f"unchanged {desired['name']}")
+    return actions
+
+
+def _reconcile_api(pool_plan: list[dict[str, Any]], backend: dict[str, Any], request) -> list[str]:
+    actions = []
+    for desired in pool_plan:
+        name = desired["name"]
+        current = request("GET", f"/pools/{quote(name, safe='')}", missing_ok=True)
+        if current is None:
+            request("POST", "/pools", body=desired)
+            actions.append(f"created {name}")
+            continue
+
+        values = _changes(current, desired, backend.get("override_pool_size", False))
+        if values:
+            request("PATCH", f"/pools/{quote(name, safe='')}", body=values)
+            actions.append(f"updated {name}: {', '.join(values)}")
+        else:
+            actions.append(f"unchanged {name}")
+    return actions
+
+
+def _changes(current: Any, desired: dict[str, Any], override_pool_size: bool) -> dict[str, Any]:
+    def get(name: str, default=None):
+        return current.get(name, default) if isinstance(current, dict) else getattr(current, name, default)
+
+    changes = {}
+    if override_pool_size and get("slots") != desired["slots"]:
+        changes["slots"] = desired["slots"]
+    if get("description") != desired["description"]:
+        changes["description"] = desired["description"]
+    if get("include_deferred", False) != desired["include_deferred"]:
+        changes["include_deferred"] = desired["include_deferred"]
+    return changes
+
+
+def _airflow3_request(backend: dict[str, Any]):
+    from airflow.sdk import Connection
+
+    connection = Connection.get(backend.get("connection_id", "airflow_laminar_api"))
+    extra = connection.extra_dejson
+    base_url = extra.get("base_url")
+    if not base_url:
+        if not connection.host:
+            raise ValueError("Airflow pool manager connection requires a host or extra.base_url")
+        host = connection.host.rstrip("/")
+        base_url = host if "://" in host else f"{connection.conn_type or 'http'}://{host}"
+        if connection.port:
+            base_url = f"{base_url}:{connection.port}"
+
+    token = extra.get("token")
+    if not token:
+        response = _http_request(
+            base_url,
+            "POST",
+            "/auth/token",
+            body={"username": connection.login, "password": connection.password},
+        )
+        token = response["access_token"]
+
+    def request(method: str, path: str, body=None, missing_ok: bool = False):
+        return _http_request(base_url, method, f"/api/v2{path}", body=body, token=token, missing_ok=missing_ok)
+
+    return request
+
+
+def _http_request(
+    base_url: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None = None,
+    token: str | None = None,
+    missing_ok: bool = False,
+):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(
+        f"{base_url.rstrip('/')}{path}",
+        data=json.dumps(body).encode() if body is not None else None,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urlopen(request, timeout=10) as response:
+            return json.loads(response.read())
+    except HTTPError as error:
+        if missing_ok and error.code == 404:
+            return None
+        raise RuntimeError(f"Airflow API request failed with HTTP {error.code}: {error.read().decode()}") from error
+
+
+def _mwaa_request(backend: dict[str, Any]):
+    import boto3
+
+    environment_name = backend.get("mwaa_environment_name")
+    if not environment_name:
+        raise ValueError("mwaa_environment_name is required for the MWAA pool manager backend")
+    client = boto3.client("mwaa", region_name=backend.get("mwaa_region_name"))
+
+    def request(method: str, path: str, body=None, missing_ok: bool = False):
+        kwargs = {"Name": environment_name, "Path": path, "Method": method}
+        if body is not None:
+            kwargs["Body"] = body
+        response = client.invoke_rest_api(**kwargs)
+        status = response["RestApiStatusCode"]
+        if missing_ok and status == 404:
+            return None
+        if not 200 <= status < 300:
+            raise RuntimeError(f"MWAA REST API request failed with HTTP {status}: {response['RestApiResponse']}")
+        result = response.get("RestApiResponse")
+        return json.loads(result) if isinstance(result, str) else result
+
+    return request

--- a/airflow_pydantic/extras/balancer/balancer.py
+++ b/airflow_pydantic/extras/balancer/balancer.py
@@ -6,10 +6,10 @@ from typing import Self
 
 from pydantic import Field, model_validator
 
-from ...airflow import create_or_update_pool, get_pool
 from ...core import BaseModel
 from ...utils import Pool, Variable
 from .host import Host
+from .pool_manager import PoolManagerConfiguration
 from .port import Port
 
 __all__ = ("BalancerConfiguration", "load_config")
@@ -47,6 +47,9 @@ class BalancerConfiguration(BaseModel):
     # create connection object in airflow for host
     create_connection: bool = False
 
+    # centrally reconcile pools from a generated task
+    pool_manager: PoolManagerConfiguration = Field(default_factory=PoolManagerConfiguration)
+
     @property
     def all_hosts(self):
         return sorted(set(self.hosts))
@@ -55,10 +58,15 @@ class BalancerConfiguration(BaseModel):
     def all_ports(self):
         return sorted(set(self.ports))
 
+    def managed_dags(self):
+        dag = self.pool_manager.build_dag(self)
+        return [] if dag is None else [dag]
+
+    def generated_files(self):
+        return self.pool_manager.generated_files(self)
+
     @model_validator(mode="after")
     def _validate(self) -> Self:
-        from airflow_pydantic.airflow import Pool as AirflowPool, PoolNotFound, get_parsing_context
-
         # Validate no duplicate hosts
         seen_hostnames = set()
         for host in self.hosts:
@@ -76,47 +84,6 @@ class BalancerConfiguration(BaseModel):
                     slots=host.size,
                     description=f"Balancer pool for host({host.name})",
                 )
-
-            if get_parsing_context().dag_id is not None:
-                # check airflow first
-                try:
-                    if isinstance(host.pool, (Pool, AirflowPool)):
-                        pool_name = host.pool.pool
-                    elif isinstance(host.pool, dict):
-                        pool_name = host.pool.get("pool")
-                    elif isinstance(host.pool, str):
-                        pool_name = host.pool
-
-                    res = get_pool(pool_name)
-
-                    # airflow return value differs version-to-version
-                    if res is None:
-                        raise PoolNotFound
-                    elif res.slots != host.size:
-                        if self.override_pool_size:
-                            create_or_update_pool(
-                                name=pool_name,
-                                slots=host.size,
-                                description=host.pool.description,
-                                include_deferred=False,
-                            )
-                        else:
-                            host.size = res.slots
-                except PoolNotFound:
-                    try:
-                        # else set to default
-                        create_or_update_pool(
-                            name=host.name,
-                            slots=host.size,
-                            description=f"Balancer pool for host({host.name})",
-                            include_deferred=False,
-                        )
-                    except Exception:  # noqa: BLE001, S110
-                        # If the database is not available, we cannot create the pool
-                        pass
-                except RuntimeError:
-                    # If the database is not available, we cannot create the pool
-                    pass
 
             if not host.username and self.default_username:
                 host.username = self.default_username
@@ -139,18 +106,6 @@ class BalancerConfiguration(BaseModel):
             if (port.host.name, port.port) in _used_ports:
                 raise ValueError(f"Duplicate port usage for host: {port.host.name}:{port.port}")
             _used_ports.add((port.host.name, port.port))
-
-            # Create pools
-            try:
-                create_or_update_pool(
-                    name=port.pool,
-                    slots=1,
-                    description=f"Balancer pool for host({port.port}) port({port.port})",
-                    include_deferred=True,
-                )
-            except Exception:  # noqa: BLE001, S110
-                # If the database is not available, we cannot create the pool
-                pass
 
         # sort hosts by name, sort ports by host name then port number
         # NOTE: since we're in a validator and we have validate_on_assignment, bypass here

--- a/airflow_pydantic/extras/balancer/pool_manager.py
+++ b/airflow_pydantic/extras/balancer/pool_manager.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime
+from importlib.resources import files
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import Field, model_validator
+
+from ...core import BaseModel, Dag, TaskArgs
+from ...utils import Pool
+from ._pool_runtime import reconcile_pools
+
+if TYPE_CHECKING:
+    from .balancer import BalancerConfiguration
+
+__all__ = ("PoolManagerConfiguration", "configured_pools")
+
+DEFAULT_DAG_ID = "airflow_laminar_pool_manager"
+GENERATED_RUNTIME_MODULE = "_airflow_laminar_pool_runtime"
+RUNTIME_IMPORT = "from airflow_pydantic.extras.balancer._pool_runtime import reconcile_pools"
+GENERATED_RUNTIME_IMPORT = f"from {GENERATED_RUNTIME_MODULE} import reconcile_pools"
+
+
+def _default_dag() -> Dag:
+    return Dag(
+        dag_id=DEFAULT_DAG_ID,
+        description="Reconcile centrally configured Airflow pools",
+        schedule="*/5 * * * *",
+        start_date=datetime(2020, 1, 1, tzinfo=UTC),
+        catchup=False,
+        max_active_runs=1,
+        is_paused_upon_creation=False,
+        tags=["airflow-laminar", "pools"],
+    )
+
+
+def _default_task() -> TaskArgs:
+    return TaskArgs(pool="default_pool", retries=2)
+
+
+class PoolManagerConfiguration(BaseModel):
+    dag: Dag = Field(default_factory=_default_dag, description="Normal Dag configuration for the generated pool manager")
+    task: TaskArgs = Field(default_factory=_default_task, description="Pool reconciliation task options")
+    task_id: str = "reconcile_pools"
+    backend: Literal["auto", "airflow2", "airflow3", "mwaa"] = "auto"
+    connection_id: str = "airflow_laminar_api"
+    mwaa_environment_name: str | None = None
+    mwaa_region_name: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_mapping_defaults(cls, value):
+        if not isinstance(value, dict):
+            return value
+
+        value = dict(value)
+        for field, defaults in (("dag", _default_dag()), ("task", _default_task())):
+            configured = value.get(field)
+            if isinstance(configured, dict):
+                merged = defaults.model_dump(exclude_unset=True)
+                merged.update(configured)
+                value[field] = merged
+        return value
+
+    @model_validator(mode="after")
+    def _apply_defaults(self):
+        for model, defaults in ((self.dag, _default_dag()), (self.task, _default_task())):
+            for field in defaults.model_fields_set - model.model_fields_set:
+                setattr(model, field, deepcopy(getattr(defaults, field)))
+        return self
+
+    def build_dag(self, config: BalancerConfiguration) -> Dag | None:
+        if self.dag.enabled is False:
+            return None
+        if self.task_id in (self.dag.tasks or {}):
+            raise ValueError(f"Pool manager Dag already contains reserved task ID {self.task_id!r}")
+
+        from ...operators.python import PythonTask
+
+        dag = self.dag.model_copy(deep=True)
+        dag.tasks = dag.tasks or {}
+        dag.tasks[self.task_id] = PythonTask(
+            **self.task.model_dump(exclude_unset=True),
+            task_id=self.task_id,
+            python_callable=reconcile_pools,
+            op_kwargs={
+                "pool_plan": [
+                    {
+                        "name": pool.pool,
+                        "slots": pool.slots,
+                        "description": pool.description,
+                        "include_deferred": pool.include_deferred,
+                    }
+                    for pool in configured_pools(config)
+                ],
+                "backend": {
+                    "kind": self.backend,
+                    "connection_id": self.connection_id,
+                    "mwaa_environment_name": self.mwaa_environment_name,
+                    "mwaa_region_name": self.mwaa_region_name,
+                    "override_pool_size": config.override_pool_size,
+                },
+            },
+            do_xcom_push=False,
+        )
+        return dag
+
+    def generated_files(self, config: BalancerConfiguration) -> dict[str, str]:
+        dag = self.build_dag(config)
+        if dag is None:
+            return {}
+        rendered = dag.render().replace(RUNTIME_IMPORT, GENERATED_RUNTIME_IMPORT)
+        return {
+            f"{GENERATED_RUNTIME_MODULE}.py": files("airflow_pydantic.extras.balancer").joinpath("_pool_runtime.py").read_text(),
+            f"{dag.dag_id}.py": rendered,
+        }
+
+
+def configured_pools(config: BalancerConfiguration) -> list[Pool]:
+    pools = []
+    for host in config.hosts:
+        if host.pool is None:
+            raise ValueError(f"Host {host.name} has no configured pool")
+        pools.append(
+            Pool(
+                pool=host.pool.pool,
+                slots=host.size,
+                description=host.pool.description,
+                include_deferred=host.pool.include_deferred,
+            )
+        )
+
+    for port in config.ports:
+        if port.host is None:
+            raise ValueError(f"Port {port.port} has no configured host")
+        pools.append(
+            Pool(
+                pool=port.pool,
+                slots=1,
+                description=f"Balancer pool for host({port.host.name}) port({port.port})",
+                include_deferred=True,
+            )
+        )
+    return pools

--- a/airflow_pydantic/testing.py
+++ b/airflow_pydantic/testing.py
@@ -11,15 +11,12 @@ def pools(return_value=None, side_effect=None):
         patch("airflow_pydantic.airflow.Pool.create_or_update_pool") as pool_create_or_update_pool_mock,
         patch("airflow_pydantic.airflow.get_pool") as get_pool_func_mock,
         patch("airflow_pydantic.airflow.create_or_update_pool") as create_or_update_pool_mock,
-        patch("airflow_pydantic.extras.balancer.balancer.get_pool") as balancer_get_pool_mock,
-        patch("airflow_pydantic.extras.balancer.balancer.create_or_update_pool") as balancer_create_or_update_pool_mock,
         patch("airflow_pydantic.airflow.get_parsing_context") as context_mock,
     ):
-        get_pool_mocks = (get_pool_mock, get_pool_func_mock, balancer_get_pool_mock)
+        get_pool_mocks = (get_pool_mock, get_pool_func_mock)
         create_pool_mocks = (
             pool_create_or_update_pool_mock,
             create_or_update_pool_mock,
-            balancer_create_or_update_pool_mock,
         )
         for pool_mock in get_pool_mocks + create_pool_mocks:
             pool_mock.return_value = return_value

--- a/airflow_pydantic/tests/core/test_render.py
+++ b/airflow_pydantic/tests/core/test_render.py
@@ -1,12 +1,7 @@
-from unittest.mock import patch
-
 from airflow_pydantic import Dag
-from airflow_pydantic.airflow import Pool
-from airflow_pydantic.testing import pools
 
 try:
     from airflow import DAG  # noqa: F401
-    from airflow.models.pool import Pool
 
     _HAVE_AIRFLOW = True
 except ImportError:
@@ -25,13 +20,12 @@ class TestRender:
         imports, globals_, task = ssh_operator.render()
         assert imports == [
             "from airflow.providers.ssh.operators.ssh import SSHOperator",
-            "from airflow.models.pool import Pool",
             "from airflow.providers.ssh.hooks.ssh import SSHHook",
         ]
         assert globals_ == []
         assert (
             task
-            == "SSHOperator(pool=Pool.get_pool('blerg').pool, do_xcom_push=True, ssh_hook=SSHHook(remote_host='test', username='test'), ssh_conn_id='test', command=\"bash -lc 'set -ex\\ntest1\\ntest2'\", cmd_timeout=10, environment={'test': 'test'}, get_pty=True, task_id='test-ssh-operator')"
+            == "SSHOperator(pool='blerg', do_xcom_push=True, ssh_hook=SSHHook(remote_host='test', username='test'), ssh_conn_id='test', command=\"bash -lc 'set -ex\\ntest1\\ntest2'\", cmd_timeout=10, environment={'test': 'test'}, get_pty=True, task_id='test-ssh-operator')"
         )
 
     def test_render_operator_ssh_airflow_3(self, ssh_operator):
@@ -50,14 +44,13 @@ class TestRender:
         imports, globals_, task = ssh_operator_balancer.render()
         assert imports == [
             "from airflow.providers.ssh.operators.ssh import SSHOperator",
-            "from airflow.models.pool import Pool",
             "from airflow.providers.ssh.hooks.ssh import SSHHook",
             "from airflow.models.variable import Variable as AirflowVariable",
         ]
         assert globals_ == []
         assert (
             task
-            == "SSHOperator(pool=Pool.create_or_update_pool(name='test_host', slots=8, description='Balancer pool for host(test_host)', include_deferred=False).pool, do_xcom_push=True, ssh_hook=SSHHook(remote_host='test_host.local', username='test_user', password=AirflowVariable.get('VAR', deserialize_json=True)['password']), ssh_conn_id='test', command='bash -lc \\'export var=\"{{ ti.blerg }}\"\\ncd /tmp\\nset -ex\\ntest1\\ntest2\\'', cmd_timeout=10, environment={'test': 'test'}, get_pty=True, task_id='test-ssh-operator')"
+            == "SSHOperator(pool='test_host', do_xcom_push=True, ssh_hook=SSHHook(remote_host='test_host.local', username='test_user', password=AirflowVariable.get('VAR', deserialize_json=True)['password']), ssh_conn_id='test', command='bash -lc \\'export var=\"{{ ti.blerg }}\"\\ncd /tmp\\nset -ex\\ntest1\\ntest2\\'', cmd_timeout=10, environment={'test': 'test'}, get_pty=True, task_id='test-ssh-operator')"
         )
 
     def test_render_operator_ssh_host_variable_airflow_3(self, ssh_operator_balancer):
@@ -77,14 +70,13 @@ class TestRender:
         imports, globals_, task = ssh_operator_balancer_template.render()
         assert imports == [
             "from airflow.providers.ssh.operators.ssh import SSHOperator",
-            "from airflow.models.pool import Pool",
             "from airflow.providers.ssh.hooks.ssh import SSHHook",
             "from airflow.models.variable import Variable as AirflowVariable",
         ]
         assert globals_ == []
         assert (
             task
-            == "SSHOperator(pool=Pool.create_or_update_pool(name='test_host', slots=8, description='Balancer pool for host(test_host)', include_deferred=False).pool, do_xcom_push=True, ssh_hook=SSHHook(remote_host='test_host.local', username='test_user', password=AirflowVariable.get('VAR', deserialize_json=True)['password']), ssh_conn_id='test', command='bash -lc \\'export var=\"{{ ti.blerg }}\"\\ncd /tmp\\nset -ex\\ntest1\\ntest2\\'', cmd_timeout=10, environment={'test': 'test'}, get_pty=True, task_id='test-ssh-operator')"
+            == "SSHOperator(pool='test_host', do_xcom_push=True, ssh_hook=SSHHook(remote_host='test_host.local', username='test_user', password=AirflowVariable.get('VAR', deserialize_json=True)['password']), ssh_conn_id='test', command='bash -lc \\'export var=\"{{ ti.blerg }}\"\\ncd /tmp\\nset -ex\\ntest1\\ntest2\\'', cmd_timeout=10, environment={'test': 'test'}, get_pty=True, task_id='test-ssh-operator')"
         )
 
     def test_render_operator_ssh_host_filter(self, ssh_operator_balancer_filter):
@@ -113,7 +105,6 @@ class TestRender:
 from datetime import datetime, time, timedelta
 
 from airflow.models import DAG
-from airflow.models.pool import Pool
 from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.providers.standard.operators.bash import BashOperator
@@ -156,7 +147,7 @@ with DAG(
     },
 ) as dag:
     task1 = PythonOperator(
-        pool=Pool.get_pool("test-pool-model").pool,
+        pool="test-pool-model",
         python_callable=foo,
         op_args=["test"],
         op_kwargs={"test": "test"},
@@ -167,7 +158,7 @@ with DAG(
         dag=dag,
     )
     task2 = BashOperator(
-        pool=Pool.create_or_update_pool(name="test", slots=5, description="", include_deferred=False).pool,
+        pool="test",
         bash_command="test",
         env={"test": "test"},
         append_env=True,
@@ -179,7 +170,7 @@ with DAG(
         dag=dag,
     )
     task3 = SSHOperator(
-        pool=Pool.get_pool("blerg").pool,
+        pool="blerg",
         do_xcom_push=True,
         ssh_hook=SSHHook(remote_host="test", username="test"),
         ssh_conn_id="test",
@@ -198,10 +189,8 @@ with DAG(
 """
         )
         if _HAVE_AIRFLOW_SSH:
-            with pools(Pool()), patch("airflow.models.pool.Pool.get_pool") as mock_get_pool:
-                mock_get_pool.return_value = Pool()
-                dag.instantiate()
-                exec(dag.render())  # noqa: S102
+            dag.instantiate()
+            exec(dag.render())  # noqa: S102
 
     def test_render_with_dependencies(self, dag):
         dag.tasks["task1"].dependencies = []
@@ -214,7 +203,6 @@ with DAG(
 from datetime import datetime, time, timedelta
 
 from airflow.models import DAG
-from airflow.models.pool import Pool
 from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.providers.standard.operators.bash import BashOperator
@@ -257,7 +245,7 @@ with DAG(
     },
 ) as dag:
     task1 = PythonOperator(
-        pool=Pool.get_pool("test-pool-model").pool,
+        pool="test-pool-model",
         python_callable=foo,
         op_args=["test"],
         op_kwargs={"test": "test"},
@@ -268,7 +256,7 @@ with DAG(
         dag=dag,
     )
     task2 = BashOperator(
-        pool=Pool.create_or_update_pool(name="test", slots=5, description="", include_deferred=False).pool,
+        pool="test",
         bash_command="test",
         env={"test": "test"},
         append_env=True,
@@ -280,7 +268,7 @@ with DAG(
         dag=dag,
     )
     task3 = SSHOperator(
-        pool=Pool.get_pool("blerg").pool,
+        pool="blerg",
         do_xcom_push=True,
         ssh_hook=SSHHook(remote_host="test", username="test"),
         ssh_conn_id="test",
@@ -302,10 +290,8 @@ with DAG(
 """
         )
         if _HAVE_AIRFLOW_SSH:
-            with pools(Pool()), patch("airflow.models.pool.Pool.get_pool") as mock_get_pool:
-                mock_get_pool.return_value = Pool()
-                dag.instantiate()
-                exec(dag.render())  # noqa: S102
+            dag.instantiate()
+            exec(dag.render())  # noqa: S102
 
     def test_render_with_externals(self, dag_with_external):
         assert isinstance(dag_with_external, Dag)
@@ -315,7 +301,6 @@ with DAG(
 from datetime import datetime, timedelta
 
 from airflow.models import DAG
-from airflow.models.pool import Pool
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.python import PythonOperator
@@ -353,7 +338,7 @@ with DAG(
     },
 ) as dag:
     task1 = PythonOperator(
-        pool=Pool.get_pool("test-pool-model").pool,
+        pool="test-pool-model",
         python_callable=foo,
         op_args=["test"],
         op_kwargs={"test": "test"},
@@ -364,7 +349,7 @@ with DAG(
         dag=dag,
     )
     task2 = BashOperator(
-        pool=Pool.create_or_update_pool(name="test", slots=5, description="", include_deferred=False).pool,
+        pool="test",
         bash_command="test",
         env={"test": "test"},
         append_env=True,
@@ -376,7 +361,7 @@ with DAG(
         dag=dag,
     )
     task3 = SSHOperator(
-        pool=Pool.get_pool("blerg").pool,
+        pool="blerg",
         do_xcom_push=True,
         ssh_hook=hook(),
         ssh_conn_id="test",
@@ -391,10 +376,8 @@ with DAG(
 """
         )
         if _HAVE_AIRFLOW_SSH:
-            with pools(Pool()), patch("airflow.models.pool.Pool.get_pool") as mock_get_pool:
-                mock_get_pool.return_value = Pool()
-                dag_with_external.instantiate()
-                exec(dag_with_external.render())  # noqa: S102
+            dag_with_external.instantiate()
+            exec(dag_with_external.render())  # noqa: S102
 
     def test_render_with_external_supervisor_config(self, dag_with_supervisor):
         assert isinstance(dag_with_supervisor, Dag)

--- a/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
+++ b/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
@@ -1,0 +1,140 @@
+from unittest.mock import MagicMock, patch
+
+from airflow_pydantic import BalancerConfiguration, Dag, Host, Pool, PoolManagerConfiguration, Port, TaskArgs
+from airflow_pydantic.extras.balancer._pool_runtime import (
+    _airflow3_request,
+    _mwaa_request,
+    _reconcile_airflow2,
+    _reconcile_api,
+)
+from airflow_pydantic.extras.balancer.pool_manager import configured_pools
+
+
+def test_pool_manager_defaults_and_dag_id_override():
+    manager = PoolManagerConfiguration(dag=Dag(dag_id="custom-pools", schedule="0 * * * *"), task=TaskArgs(queue="system"))
+
+    assert manager.dag.dag_id == "custom-pools"
+    assert manager.dag.schedule == "0 * * * *"
+    assert manager.dag.catchup is False
+    assert manager.dag.max_active_runs == 1
+    assert manager.dag.is_paused_upon_creation is False
+    assert manager.task.queue == "system"
+    assert manager.task.pool == "default_pool"
+    assert manager.task.retries == 2
+
+
+def test_pool_manager_dag_options_do_not_require_id_override():
+    manager = PoolManagerConfiguration(dag={"schedule": "0 * * * *", "tags": ["platform"]})
+
+    assert manager.dag.dag_id == "airflow_laminar_pool_manager"
+    assert manager.dag.schedule == "0 * * * *"
+    assert manager.dag.tags == ["platform"]
+    assert manager.dag.catchup is False
+
+
+def test_configured_pools_and_generated_files_are_runtime_independent():
+    config = BalancerConfiguration(
+        hosts=[Host(name="host", size=4, pool=Pool(pool="host-pool", description="Host pool"))],
+        ports=[Port(host_name="host", port=22)],
+        pool_manager={"dag": {"dag_id": "custom-pools"}, "backend": "mwaa", "mwaa_environment_name": "environment"},
+    )
+
+    assert [pool.model_dump() for pool in configured_pools(config)] == [
+        {"pool": "host-pool", "slots": 4, "description": "Host pool", "include_deferred": False},
+        {"pool": "host-22", "slots": 1, "description": "Balancer pool for host(host) port(22)", "include_deferred": True},
+    ]
+
+    generated = config.generated_files()
+    assert set(generated) == {"_airflow_laminar_pool_runtime.py", "custom-pools.py"}
+    assert all("airflow_pydantic" not in source for source in generated.values())
+    assert '"name": "host-pool"' in generated["custom-pools.py"]
+    assert '"mwaa_environment_name": "environment"' in generated["custom-pools.py"]
+    for filename, source in generated.items():
+        compile(source, filename, "exec")
+
+
+def test_configuration_does_not_access_airflow_pools():
+    with (
+        patch("airflow_pydantic.airflow.get_pool") as get_pool,
+        patch("airflow_pydantic.airflow.create_or_update_pool") as create_pool,
+    ):
+        BalancerConfiguration(hosts=[Host(name="host")], ports=[Port(host_name="host", port=22)])
+
+    get_pool.assert_not_called()
+    create_pool.assert_not_called()
+
+
+def test_api_reconciliation_creates_updates_and_preserves_slots():
+    existing = {
+        "changed": {"name": "changed", "slots": 10, "description": "Old", "include_deferred": True},
+        "unchanged": {"name": "unchanged", "slots": 8, "description": "Configured", "include_deferred": False},
+    }
+    request = MagicMock()
+
+    def request_side_effect(method, path, body=None, missing_ok=False):
+        if method == "GET":
+            return existing.get(path.rsplit("/", 1)[-1])
+        return {}
+
+    request.side_effect = request_side_effect
+    plan = [
+        {"name": "new", "slots": 2, "description": "New", "include_deferred": False},
+        {"name": "changed", "slots": 4, "description": "Configured", "include_deferred": False},
+        {"name": "unchanged", "slots": 8, "description": "Configured", "include_deferred": False},
+    ]
+
+    actions = _reconcile_api(plan, {"override_pool_size": False}, request)
+
+    assert actions == ["created new", "updated changed: description, include_deferred", "unchanged unchanged"]
+    request.assert_any_call("POST", "/pools", body=plan[0])
+    request.assert_any_call("PATCH", "/pools/changed", body={"description": "Configured", "include_deferred": False})
+
+
+def test_airflow2_reconciliation_runs_from_the_task():
+    current = MagicMock(slots=10, description="Old", include_deferred=True)
+    desired = {"name": "pool", "slots": 4, "description": "Configured", "include_deferred": False}
+
+    with (
+        patch("airflow.models.pool.Pool.get_pool", return_value=current) as get_pool,
+        patch("airflow.models.pool.Pool.create_or_update_pool") as create_or_update_pool,
+    ):
+        actions = _reconcile_airflow2([desired], {"override_pool_size": False})
+
+    assert actions == ["updated pool: description, include_deferred"]
+    get_pool.assert_called_once_with("pool")
+    create_or_update_pool.assert_called_once_with("pool", 10, "Configured", False)
+
+
+def test_airflow3_backend_uses_task_sdk_connection():
+    connection = MagicMock(
+        host="airflow-api",
+        conn_type="http",
+        port=8080,
+        extra_dejson={"token": "token"},
+    )
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = b'{"name": "pool"}'
+
+    with (
+        patch("airflow.sdk.Connection.get", return_value=connection) as get_connection,
+        patch("airflow_pydantic.extras.balancer._pool_runtime.urlopen", return_value=response) as open_url,
+    ):
+        request = _airflow3_request({"connection_id": "pool-api"})
+        assert request("GET", "/pools/pool") == {"name": "pool"}
+
+    get_connection.assert_called_once_with("pool-api")
+    api_request = open_url.call_args.args[0]
+    assert api_request.full_url == "http://airflow-api:8080/api/v2/pools/pool"
+    assert api_request.headers["Authorization"] == "Bearer token"
+
+
+def test_mwaa_backend_uses_iam_rest_api():
+    boto_client = MagicMock()
+    boto_client.invoke_rest_api.return_value = {"RestApiStatusCode": 200, "RestApiResponse": {"name": "pool"}}
+
+    with patch("boto3.client", return_value=boto_client) as boto_client_factory:
+        request = _mwaa_request({"mwaa_environment_name": "environment", "mwaa_region_name": "us-east-1"})
+        assert request("GET", "/pools/pool") == {"name": "pool"}
+
+    boto_client_factory.assert_called_once_with("mwaa", region_name="us-east-1")
+    boto_client.invoke_rest_api.assert_called_once_with(Name="environment", Path="/pools/pool", Method="GET")

--- a/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
+++ b/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
@@ -1,3 +1,5 @@
+import sys
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 from airflow_pydantic import BalancerConfiguration, Dag, Host, Pool, PoolManagerConfiguration, Port, TaskArgs
@@ -93,16 +95,19 @@ def test_api_reconciliation_creates_updates_and_preserves_slots():
 def test_airflow2_reconciliation_runs_from_the_task():
     current = MagicMock(slots=10, description="Old", include_deferred=True)
     desired = {"name": "pool", "slots": 4, "description": "Configured", "include_deferred": False}
+    pool = MagicMock()
+    pool.get_pool.return_value = current
+    airflow = ModuleType("airflow")
+    models = ModuleType("airflow.models")
+    pool_module = ModuleType("airflow.models.pool")
+    pool_module.Pool = pool
 
-    with (
-        patch("airflow.models.pool.Pool.get_pool", return_value=current) as get_pool,
-        patch("airflow.models.pool.Pool.create_or_update_pool") as create_or_update_pool,
-    ):
+    with patch.dict(sys.modules, {"airflow": airflow, "airflow.models": models, "airflow.models.pool": pool_module}):
         actions = _reconcile_airflow2([desired], {"override_pool_size": False})
 
     assert actions == ["updated pool: description, include_deferred"]
-    get_pool.assert_called_once_with("pool")
-    create_or_update_pool.assert_called_once_with("pool", 10, "Configured", False)
+    pool.get_pool.assert_called_once_with("pool")
+    pool.create_or_update_pool.assert_called_once_with("pool", 10, "Configured", False)
 
 
 def test_airflow3_backend_uses_task_sdk_connection():
@@ -114,15 +119,20 @@ def test_airflow3_backend_uses_task_sdk_connection():
     )
     response = MagicMock()
     response.__enter__.return_value.read.return_value = b'{"name": "pool"}'
+    connection_api = MagicMock()
+    connection_api.get.return_value = connection
+    airflow = ModuleType("airflow")
+    sdk = ModuleType("airflow.sdk")
+    sdk.Connection = connection_api
 
     with (
-        patch("airflow.sdk.Connection.get", return_value=connection) as get_connection,
+        patch.dict(sys.modules, {"airflow": airflow, "airflow.sdk": sdk}),
         patch("airflow_pydantic.extras.balancer._pool_runtime.urlopen", return_value=response) as open_url,
     ):
         request = _airflow3_request({"connection_id": "pool-api"})
         assert request("GET", "/pools/pool") == {"name": "pool"}
 
-    get_connection.assert_called_once_with("pool-api")
+    connection_api.get.assert_called_once_with("pool-api")
     api_request = open_url.call_args.args[0]
     assert api_request.full_url == "http://airflow-api:8080/api/v2/pools/pool"
     assert api_request.headers["Authorization"] == "Bearer token"
@@ -131,10 +141,12 @@ def test_airflow3_backend_uses_task_sdk_connection():
 def test_mwaa_backend_uses_iam_rest_api():
     boto_client = MagicMock()
     boto_client.invoke_rest_api.return_value = {"RestApiStatusCode": 200, "RestApiResponse": {"name": "pool"}}
+    boto3 = ModuleType("boto3")
+    boto3.client = MagicMock(return_value=boto_client)
 
-    with patch("boto3.client", return_value=boto_client) as boto_client_factory:
+    with patch.dict(sys.modules, {"boto3": boto3}):
         request = _mwaa_request({"mwaa_environment_name": "environment", "mwaa_region_name": "us-east-1"})
         assert request("GET", "/pools/pool") == {"name": "pool"}
 
-    boto_client_factory.assert_called_once_with("mwaa", region_name="us-east-1")
+    boto3.client.assert_called_once_with("mwaa", region_name="us-east-1")
     boto_client.invoke_rest_api.assert_called_once_with(Name="environment", Path="/pools/pool", Method="GET")


### PR DESCRIPTION
## Description

Move centrally configured pool reconciliation out of DAG parsing and into a generated Airflow task. Airflow 2 uses its ORM at task time, Airflow 3 uses the public REST API through an Airflow connection, and MWAA uses `InvokeRestApi` with the task role.

`generate()` emits the pool manager and a standalone runtime module, so generated deployments do not need airflow-pydantic installed on workers. The manager DAG and task retain normal airflow-pydantic configuration, including DAG ID, schedule, tags, queue, and retry overrides.

This removes parser-time pool reads and writes while preserving centrally managed pool definitions.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`263 passed, 6 skipped` against current Airflow main)
- [x] New tests added for new functionality
- [x] Documentation updated (not applicable; configuration fields are self-describing)
- [x] Changelog / version bump (not applicable)
