### PR TITLE
Extend Airflow 3 support bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ airflow = [
     "apache-airflow-providers-standard",
 ]
 airflow3 = [
-    "apache-airflow>=3,<3.2",
+    "apache-airflow>=3,<3.4",
     "apache-airflow-providers-smtp",
     "apache-airflow-providers-ssh",
     "apache-airflow-providers-standard",
@@ -75,7 +75,7 @@ laminar = [
     "airflow-supervisor>=1.9",
     "supervisor-pydantic",
     # Airflow
-    "apache-airflow>=2.8,<3.2",
+    "apache-airflow>=2.8,<3.4",
     "apache-airflow-providers-smtp",
     "apache-airflow-providers-ssh",
     "apache-airflow-providers-standard",


### PR DESCRIPTION
Allow Airflow 3 installations through 3.3 by widening the `airflow3` and `laminar` optional dependency bounds to `<3.4`. This lets the existing CI matrix exercise newer Airflow 3 releases without changing package versions or runtime behavior.

Local checks: `make lint`; 263 tests passed and 6 skipped against the local Airflow main environment.