### PR TITLE
Require compatible Laminar packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,11 @@ airflow3 = [
 ]
 laminar = [
     # Laminar
-    "airflow-balancer",
-    "airflow-config",
-    "airflow-common-operators",
-    "airflow-ha",
-    "airflow-supervisor>=1.9",
+    "airflow-balancer>=0.7.8",
+    "airflow-config>=1.12",
+    "airflow-common>=0.7.9",
+    "airflow-ha>=1.6.3",
+    "airflow-supervisor>=1.10.3",
     "supervisor-pydantic",
     # Airflow
     "apache-airflow>=2.8,<3.4",


### PR DESCRIPTION
Require released Laminar versions compatible with airflow-pydantic 1.6 and replace the obsolete `airflow-common-operators` dependency with `airflow-common`.

This removes the reverse-dependency resolver conflict in the Laminar CI matrix and repairs the published `[laminar]` extra for the next patch release.

Validated with a fresh `[develop,laminar]` resolution selecting Airflow 3.3.0 and the full released stack, `make lint`, and 263 passing tests (6 skipped) against local Airflow main.
