### PR TITLE
Inline generated pool runtime

### DIFF
--- a/airflow_pydantic/extras/balancer/pool_manager.py
+++ b/airflow_pydantic/extras/balancer/pool_manager.py
@@ -17,9 +17,8 @@ if TYPE_CHECKING:
 __all__ = ("PoolManagerConfiguration", "configured_pools")
 
 DEFAULT_DAG_ID = "airflow_laminar_pool_manager"
-GENERATED_RUNTIME_MODULE = "_airflow_laminar_pool_runtime"
 RUNTIME_IMPORT = "from airflow_pydantic.extras.balancer._pool_runtime import reconcile_pools"
-GENERATED_RUNTIME_IMPORT = f"from {GENERATED_RUNTIME_MODULE} import reconcile_pools"
+FUTURE_ANNOTATIONS_IMPORT = "from __future__ import annotations\n\n"
 
 
 def _default_dag() -> Dag:
@@ -110,11 +109,9 @@ class PoolManagerConfiguration(BaseModel):
         dag = self.build_dag(config)
         if dag is None:
             return {}
-        rendered = dag.render().replace(RUNTIME_IMPORT, GENERATED_RUNTIME_IMPORT)
-        return {
-            f"{GENERATED_RUNTIME_MODULE}.py": files("airflow_pydantic.extras.balancer").joinpath("_pool_runtime.py").read_text(),
-            f"{dag.dag_id}.py": rendered,
-        }
+        runtime = files("airflow_pydantic.extras.balancer").joinpath("_pool_runtime.py").read_text()
+        rendered = dag.render().replace(RUNTIME_IMPORT, runtime.removeprefix(FUTURE_ANNOTATIONS_IMPORT).rstrip())
+        return {f"{dag.dag_id}.py": rendered}
 
 
 def configured_pools(config: BalancerConfiguration) -> list[Pool]:

--- a/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
+++ b/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
@@ -1,4 +1,5 @@
 import sys
+from importlib.util import module_from_spec, spec_from_file_location
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
@@ -47,12 +48,32 @@ def test_configured_pools_and_generated_files_are_runtime_independent():
     ]
 
     generated = config.generated_files()
-    assert set(generated) == {"_airflow_laminar_pool_runtime.py", "custom-pools.py"}
+    assert set(generated) == {"custom-pools.py"}
     assert all("airflow_pydantic" not in source for source in generated.values())
+    assert "sys.path" not in generated["custom-pools.py"]
+    assert "def reconcile_pools(" in generated["custom-pools.py"]
     assert '"name": "host-pool"' in generated["custom-pools.py"]
     assert '"mwaa_environment_name": "environment"' in generated["custom-pools.py"]
     for filename, source in generated.items():
         compile(source, filename, "exec")
+
+
+def test_generated_pool_dag_loads_from_nested_directory(tmp_path):
+    config = BalancerConfiguration(
+        hosts=[Host(name="host")],
+        pool_manager={"dag": {"dag_id": "custom-pools"}},
+    )
+    generated_dir = tmp_path / "nested"
+    generated_dir.mkdir()
+    for filename, source in config.generated_files().items():
+        (generated_dir / filename).write_text(source)
+
+    spec = spec_from_file_location("custom_pools", generated_dir / "custom-pools.py")
+    assert spec is not None and spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.dag.dag_id == "custom-pools"
 
 
 def test_configuration_does_not_access_airflow_pools():

--- a/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
+++ b/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
@@ -1,7 +1,9 @@
 import sys
-from importlib.util import module_from_spec, spec_from_file_location
+from importlib.util import find_spec, module_from_spec, spec_from_file_location
 from types import ModuleType
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from airflow_pydantic import BalancerConfiguration, Dag, Host, Pool, PoolManagerConfiguration, Port, TaskArgs
 from airflow_pydantic.extras.balancer._pool_runtime import (
@@ -58,6 +60,7 @@ def test_configured_pools_and_generated_files_are_runtime_independent():
         compile(source, filename, "exec")
 
 
+@pytest.mark.skipif(find_spec("airflow") is None, reason="Airflow is not installed")
 def test_generated_pool_dag_loads_from_nested_directory(tmp_path):
     config = BalancerConfiguration(
         hosts=[Host(name="host")],


### PR DESCRIPTION
Generated pool-manager DAGs now inline their task-time reconciliation runtime instead of importing a generated sibling module.

Airflow 2 does not add nested DAG directories to `sys.path`, so the sibling import failed when generated files were deployed below the DAG root. A self-contained DAG avoids parser path assumptions and keeps generated deployments independent of `airflow-pydantic` and `airflow-config` at runtime.

Validated with the full 270-test suite, lint, distribution checks, nested DAG loading, live Airflow 2.11 and 3.3 CeleryExecutor stacks, clean Airflow 2.11/3.2.1/3.3 images, and the MWAA REST request path.
