### PR TITLE
Propagate Airflow version through rendering

### DIFF
--- a/airflow_pydantic/core/render/dag.py
+++ b/airflow_pydantic/core/render/dag.py
@@ -46,7 +46,11 @@ class DagRenderMixin:
                 dag_args[k] = ast.Constant(value=value)
 
         if self.default_args:
-            dag_default_args_imports, dag_default_args_globals, dag_default_args_values = render_base_task_args(self.default_args, raw=True)
+            dag_default_args_imports, dag_default_args_globals, dag_default_args_values = render_base_task_args(
+                self.default_args,
+                raw=True,
+                airflow_major_version=airflow_major_version,
+            )
             imports.extend(dag_default_args_imports)
             globals_.extend(dag_default_args_globals)
             dag_args["default_args"] = dag_default_args_values
@@ -55,7 +59,11 @@ class DagRenderMixin:
         dag_args = [ast.keyword(arg=k, value=v) for k, v in dag_args.items()]
 
         for task_key, task in self.tasks.items():
-            task_imports, task_globals, task_code = task.render(raw=True, dag_from_context=True)
+            task_imports, task_globals, task_code = task.render(
+                raw=True,
+                dag_from_context=True,
+                airflow_major_version=airflow_major_version,
+            )
             imports.extend(task_imports)
             globals_.extend(task_globals)
 

--- a/airflow_pydantic/extras/balancer/balancer.py
+++ b/airflow_pydantic/extras/balancer/balancer.py
@@ -62,8 +62,8 @@ class BalancerConfiguration(BaseModel):
         dag = self.pool_manager.build_dag(self)
         return [] if dag is None else [dag]
 
-    def generated_files(self):
-        return self.pool_manager.generated_files(self)
+    def generated_files(self, airflow_major_version: int = 2):
+        return self.pool_manager.generated_files(self, airflow_major_version=airflow_major_version)
 
     @model_validator(mode="after")
     def _validate(self) -> Self:

--- a/airflow_pydantic/extras/balancer/pool_manager.py
+++ b/airflow_pydantic/extras/balancer/pool_manager.py
@@ -105,12 +105,15 @@ class PoolManagerConfiguration(BaseModel):
         )
         return dag
 
-    def generated_files(self, config: BalancerConfiguration) -> dict[str, str]:
+    def generated_files(self, config: BalancerConfiguration, airflow_major_version: int = 2) -> dict[str, str]:
         dag = self.build_dag(config)
         if dag is None:
             return {}
         runtime = files("airflow_pydantic.extras.balancer").joinpath("_pool_runtime.py").read_text()
-        rendered = dag.render().replace(RUNTIME_IMPORT, runtime.removeprefix(FUTURE_ANNOTATIONS_IMPORT).rstrip())
+        rendered = dag.render(airflow_major_version=airflow_major_version).replace(
+            RUNTIME_IMPORT,
+            runtime.removeprefix(FUTURE_ANNOTATIONS_IMPORT).rstrip(),
+        )
         return {f"{dag.dag_id}.py": rendered}
 
 

--- a/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
+++ b/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
@@ -37,7 +37,7 @@ def test_pool_manager_dag_options_do_not_require_id_override():
     assert manager.dag.catchup is False
 
 
-def test_configured_pools_and_generated_files_are_runtime_independent():
+def test_configured_pools_and_generated_files_are_runtime_independent(monkeypatch):
     config = BalancerConfiguration(
         hosts=[Host(name="host", size=4, pool=Pool(pool="host-pool", description="Host pool"))],
         ports=[Port(host_name="host", port=22)],
@@ -49,7 +49,16 @@ def test_configured_pools_and_generated_files_are_runtime_independent():
         {"pool": "host-22", "slots": 1, "description": "Balancer pool for host(host) port(22)", "include_deferred": True},
     ]
 
-    generated = config.generated_files()
+    airflow_versions = []
+    original_render = Dag.render
+
+    def render(dag, *args, **kwargs):
+        airflow_versions.append(kwargs["airflow_major_version"])
+        return original_render(dag, *args, **kwargs)
+
+    monkeypatch.setattr(Dag, "render", render)
+    generated = config.generated_files(airflow_major_version=3)
+    assert airflow_versions == [3]
     assert set(generated) == {"custom-pools.py"}
     assert all("airflow_pydantic" not in source for source in generated.values())
     assert "sys.path" not in generated["custom-pools.py"]


### PR DESCRIPTION
## Description

Propagate the requested Airflow major version from DAG rendering into default arguments, tasks, balancer extensions, and generated pool-manager DAGs. This lets dependency-free file generation target Airflow 2 or 3 without consulting an installed Airflow package.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (make lint)
- [ ] Tests pass (make test)
- [x] New tests added for new functionality
- [ ] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)

Relevant render and pool-manager tests pass: 21 passed, 1 skipped. Full Airflow-free suite retains seven pre-existing failures outside this change.