### PR TITLE
Tolerate unresolvable variable passwords when building a host hook

### DIFF
--- a/airflow_pydantic/core/render/utils.py
+++ b/airflow_pydantic/core/render/utils.py
@@ -163,6 +163,9 @@ def _build_ssh_hook_with_variable(host, call: ast.Call) -> tuple[list[ast.Import
                     level=0,
                 )
             )
+        else:
+            # Guards against emitting a hook with a missing or placeholder password
+            raise ValueError(f"Host password is variable `{host.password.key}` but the rendered ssh_hook has no password to substitute")
     return imports, call
 
 

--- a/airflow_pydantic/extras/balancer/host.py
+++ b/airflow_pydantic/extras/balancer/host.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 from pydantic import Field
@@ -10,6 +11,12 @@ if TYPE_CHECKING:
 
 
 __all__ = ("Host",)
+
+_log = getLogger(__name__)
+
+# Stand-in for a Variable password that cannot be resolved offline. Rendering always
+# replaces it with a Variable.get call, so it must never reach a generated DAG.
+UNRESOLVED_PASSWORD = "<unresolved airflow-pydantic variable>"
 
 
 class Host(BaseModel):
@@ -51,7 +58,13 @@ class Host(BaseModel):
         if username and self.password:
             if isinstance(self.password, str):
                 return _hook(remote_host=name, username=username, password=self.password, **hook_kwargs)
-            password = self.password.get()
+            try:
+                password = self.password.get()
+            except Exception:  # noqa: BLE001
+                # No Airflow metadata database available, e.g. when generating DAG files offline.
+                # Rendering rewrites this into a Variable.get call, so the value itself is unused.
+                _log.info("Could not resolve variable %s, falling back to an unresolved password", self.password.key)
+                password = UNRESOLVED_PASSWORD
             if isinstance(password, dict):
                 # TODO
                 # Assume "password"

--- a/airflow_pydantic/tests/extras/balancer/test_balancer_host.py
+++ b/airflow_pydantic/tests/extras/balancer/test_balancer_host.py
@@ -2,6 +2,7 @@ from getpass import getuser
 
 from airflow_pydantic import BalancerConfiguration, Host, Variable
 from airflow_pydantic.airflow import PoolNotFound
+from airflow_pydantic.extras.balancer.host import UNRESOLVED_PASSWORD
 from airflow_pydantic.testing import pools, variables
 
 
@@ -66,6 +67,16 @@ class TestConfig:
         assert h.hook().remote_host == "test.local"
         assert h.hook().password is None
         assert h.hook().key_file is None
+
+    def test_load_hook_unresolvable_variable(self):
+        h = Host(name="test", username="test", password=Variable(key="test"))
+
+        with variables(side_effect=RuntimeError("no metadata database")):
+            hook = h.hook()
+
+        assert hook.username == "test"
+        assert hook.remote_host == "test.local"
+        assert hook.password == UNRESOLVED_PASSWORD
 
     def test_filter_hosts(self):
         with pools(side_effect=PoolNotFound()):


### PR DESCRIPTION
Host.hook resolved a Variable password eagerly, so building a hook without an Airflow metadata database raised and the SSH validator swallowed it into a None ssh_hook. Rendering then failed on that None. Generating DAG files is inherently offline, and the renderer rewrites the password into a Variable.get call anyway, so the resolved value is never used.

Fall back to a placeholder when the lookup fails, and raise if rendering ever finds no password keyword to substitute, so the placeholder cannot reach a generated DAG.