### PR TITLE
Support Airflow 3 and MWAA in DAG cleanup tasks

### DIFF
--- a/airflow_pydantic/extras/balancer/_pool_runtime.py
+++ b/airflow_pydantic/extras/balancer/_pool_runtime.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
+import os
 from importlib.metadata import version
 from typing import Any
 from urllib.error import HTTPError
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
 POOL_RUNTIME_VERSION = 1
@@ -127,8 +128,8 @@ def _airflow3_request(backend: dict[str, Any]):
         )
         token = response["access_token"]
 
-    def request(method: str, path: str, body=None, missing_ok: bool = False):
-        return _http_request(base_url, method, f"/api/v2{path}", body=body, token=token, missing_ok=missing_ok)
+    def request(method: str, path: str, query=None, body=None, missing_ok: bool = False):
+        return _http_request(base_url, method, f"/api/v2{path}", query=query, body=body, token=token, missing_ok=missing_ok)
 
     return request
 
@@ -137,6 +138,7 @@ def _http_request(
     base_url: str,
     method: str,
     path: str,
+    query: dict[str, Any] | None = None,
     body: dict[str, Any] | None = None,
     token: str | None = None,
     missing_ok: bool = False,
@@ -144,15 +146,19 @@ def _http_request(
     headers = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    url = f"{base_url.rstrip('/')}{path}"
+    if query:
+        url = f"{url}?{urlencode(query)}"
     request = Request(
-        f"{base_url.rstrip('/')}{path}",
+        url,
         data=json.dumps(body).encode() if body is not None else None,
         headers=headers,
         method=method,
     )
     try:
         with urlopen(request, timeout=10) as response:
-            return json.loads(response.read())
+            payload = response.read()
+        return json.loads(payload) if payload else None
     except HTTPError as error:
         if missing_ok and error.code == 404:
             return None
@@ -162,13 +168,15 @@ def _http_request(
 def _mwaa_request(backend: dict[str, Any]):
     import boto3
 
-    environment_name = backend.get("mwaa_environment_name")
+    environment_name = backend.get("mwaa_environment_name") or os.environ.get("AIRFLOW_ENV_NAME")
     if not environment_name:
-        raise ValueError("mwaa_environment_name is required for the MWAA pool manager backend")
+        raise ValueError("mwaa_environment_name is required for the MWAA backend")
     client = boto3.client("mwaa", region_name=backend.get("mwaa_region_name"))
 
-    def request(method: str, path: str, body=None, missing_ok: bool = False):
+    def request(method: str, path: str, query=None, body=None, missing_ok: bool = False):
         kwargs = {"Name": environment_name, "Path": path, "Method": method}
+        if query:
+            kwargs["QueryParameters"] = query
         if body is not None:
             kwargs["Body"] = body
         response = client.invoke_rest_api(**kwargs)

--- a/airflow_pydantic/extras/common/airflow_functions.py
+++ b/airflow_pydantic/extras/common/airflow_functions.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime, timedelta
 from logging import getLogger
+from urllib.parse import quote
 
 from pytz import UTC
 
@@ -8,7 +9,9 @@ from ...airflow import AirflowFailException, AirflowSkipException
 
 __all__ = (
     "clean_dag_runs",
+    "clean_dag_runs_api",
     "clean_dags",
+    "clean_dags_api",
     "fail",
     "pass_",
     "skip",
@@ -120,3 +123,179 @@ def clean_dags(session, **context):
     _log.info("Committing DAG deletions")
     session.commit()
     _log.info(f"Total DAGs deleted: {len(entries_to_delete)}")
+
+
+def _get_api_base_url(base_url=None):
+    if base_url:
+        return base_url.rstrip("/")
+    if os.environ.get("AIRFLOW__API__BASE_URL"):
+        return os.environ["AIRFLOW__API__BASE_URL"].rstrip("/")
+    # Workers always know the execution API server, which shares a base with the public API
+    if os.environ.get("AIRFLOW__CORE__EXECUTION_API_SERVER_URL"):
+        return os.environ["AIRFLOW__CORE__EXECUTION_API_SERVER_URL"].rstrip("/").removesuffix("/execution")
+    try:
+        from airflow.configuration import conf
+
+        url = conf.get("api", "base_url", fallback=None)
+        if url:
+            return url.rstrip("/")
+    except Exception as e:  # noqa: BLE001
+        _log.debug(f"Could not read api base_url from airflow config: {e}")
+    return "http://localhost:8080"
+
+
+def _get_api_token(base_url, token=None, username=None, password=None):
+    from ..balancer._pool_runtime import _http_request
+
+    token = token or os.environ.get("AIRFLOW_API_TOKEN") or os.environ.get("AIRFLOW_CLI_TOKEN")
+    if token:
+        return token
+    username = username or os.environ.get("AIRFLOW_API_USERNAME")
+    password = password or os.environ.get("AIRFLOW_API_PASSWORD")
+    try:
+        if username and password:
+            return _http_request(base_url, "POST", "/auth/token", body={"username": username, "password": password})["access_token"]
+        # Simple auth manager with all-admins mode issues tokens without credentials
+        return _http_request(base_url, "GET", "/auth/token")["access_token"]
+    except RuntimeError as e:
+        raise RuntimeError(
+            f"Could not authenticate to the Airflow API at {base_url}: {e}. Set AIRFLOW_API_TOKEN, or AIRFLOW_API_USERNAME and AIRFLOW_API_PASSWORD."
+        ) from e
+
+
+def _create_api_request(backend=None):
+    """Build a request callable for the Airflow REST API, sharing the balancer pool runtime backends.
+
+    Backends: "airflow3" resolves credentials from an Airflow connection (falling back to
+    environment variables), "mwaa" uses boto3 invoke_rest_api with the worker's IAM role.
+    "auto" picks mwaa when an MWAA environment is configured or detected.
+    """
+    from ..balancer import _pool_runtime
+
+    backend = backend or {}
+    kind = backend.get("kind", "auto")
+    if kind == "auto":
+        kind = "mwaa" if (backend.get("mwaa_environment_name") or os.environ.get("AIRFLOW_ENV_NAME")) else "airflow3"
+
+    if kind == "mwaa":
+        return _pool_runtime._mwaa_request(backend)
+
+    try:
+        return _pool_runtime._airflow3_request(backend)
+    except Exception as e:  # noqa: BLE001
+        _log.debug(f"Could not create API client from connection: {e}")
+
+    base_url = _get_api_base_url(backend.get("base_url"))
+    token = _get_api_token(base_url, token=backend.get("token"))
+
+    def request(method, path, query=None, body=None, missing_ok=False):
+        return _pool_runtime._http_request(base_url, method, f"/api/v2{path}", query=query, body=body, token=token, missing_ok=missing_ok)
+
+    return request
+
+
+def _api_get_paginated(request, path, key, **query):
+    items = []
+    offset = 0
+    while True:
+        response = request("GET", path, query={"limit": 100, "offset": offset, **query})
+        batch = list(response.get(key) or [])
+        items.extend(batch)
+        total = response.get("total_entries")
+        if not batch or (total is not None and len(items) >= total):
+            return items
+        offset += len(batch)
+
+
+def _dag_run_date(run):
+    value = run.get("logical_date") or run.get("run_after") or run.get("start_date")
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def clean_dag_runs_api(delete_successful, delete_failed, mark_failed_as_successful, max_dagruns, days_to_keep, backend=None):
+    """REST API implementation of clean_dag_runs, for Airflow 3 where tasks have no database access."""
+    request = _create_api_request(backend)
+
+    utc_now = datetime.now(tz=UTC)
+    cutoff_date = utc_now - timedelta(days=days_to_keep)
+    _log.info(f"Cutoff date for clean: {cutoff_date}")
+
+    dags = _api_get_paginated(request, "/dags", "dags", exclude_stale="false")
+    dag_ids = [d["dag_id"] for d in dags]
+    _log.info(f"Found DAGs to clean up: {dag_ids}")
+
+    deleted = 0
+
+    for dag_id in dag_ids:
+        _log.info(f"Cleaning up DAG: {dag_id}")
+
+        runs_path = f"/dags/{quote(dag_id, safe='')}/dagRuns"
+        runs = _api_get_paginated(request, runs_path, "dag_runs")
+
+        if delete_successful is False:
+            _log.info(f"Not deleting successful DAG runs for DAG: {dag_id}")
+            runs = [r for r in runs if r["state"] != "success"]
+        if delete_failed is False:
+            _log.info(f"Not deleting failed DAG runs for DAG: {dag_id}")
+            runs = [r for r in runs if r["state"] != "failed"]
+
+        runs.sort(key=lambda r: _dag_run_date(r) or utc_now)
+        total_runs = len(runs)
+        _log.info(f"Found {total_runs} DAG runs to clean up for DAG: {dag_id}")
+
+        for run in runs:
+            run_id = run["dag_run_id"]
+            run_date = _dag_run_date(run)
+            if (run_date is not None and run_date < cutoff_date) or total_runs > max_dagruns:
+                if run["state"] not in ("queued", "success", "failed"):
+                    # The API only allows deleting runs in queued/success/failed states
+                    _log.info(f"Skipping DAG run in {run['state']} state: {run_id}")
+                    continue
+                _log.info(f"Deleting DAG run: {run_id}")
+                try:
+                    request("DELETE", f"{runs_path}/{quote(run_id, safe='')}")
+                except RuntimeError as e:
+                    _log.warning(f"Failed to delete DAG run {run_id}: {e}")
+                    continue
+                deleted += 1
+                total_runs -= 1
+            elif mark_failed_as_successful:
+                # Need to iterate through all remaining
+                if run["state"] == "failed":
+                    _log.info(f"Marking failed DAG run as successful: {run_id}")
+                    request("PATCH", f"{runs_path}/{quote(run_id, safe='')}", body={"state": "success"})
+            else:
+                break  # Since they are ordered, no more to delete
+
+    _log.info(f"Total DAG runs deleted: {deleted}")
+
+
+def clean_dags_api(backend=None):
+    """REST API implementation of clean_dags, for Airflow 3 where tasks have no database access.
+
+    Instead of checking file existence locally (meaningless on a worker), deletes DAGs the
+    dag processor has marked stale (their file or bundle no longer exists).
+    """
+    request = _create_api_request(backend)
+
+    _log.info("Starting to run Clear Process")
+
+    dags = _api_get_paginated(request, "/dags", "dags", exclude_stale="false")
+    _log.info(f"Found DAGs: {len(dags)}")
+
+    stale_dag_ids = [d["dag_id"] for d in dags if d.get("is_stale")]
+    _log.info(f"Deleting dags:\n{len(stale_dag_ids)}")
+
+    for dag_id in stale_dag_ids:
+        _log.info(f"Deleting stale DAG: {dag_id}")
+        try:
+            request("DELETE", f"/dags/{quote(dag_id, safe='')}")
+        except RuntimeError as e:
+            _log.warning(f"Failed to delete DAG {dag_id}: {e}")
+
+    _log.info(f"Total DAGs deleted: {len(stale_dag_ids)}")

--- a/airflow_pydantic/extras/common/clean.py
+++ b/airflow_pydantic/extras/common/clean.py
@@ -1,9 +1,12 @@
+from typing import Literal
+
 from pydantic import Field, field_validator
 
 from ...airflow import PythonOperator
 from ...core import Task, TaskArgs
+from ...migration import _airflow_3
 from ...utils import CallablePath
-from .airflow_functions import clean_dag_runs, clean_dags
+from .airflow_functions import clean_dag_runs, clean_dag_runs_api, clean_dags, clean_dags_api
 
 __all__ = (
     "DagClean",
@@ -15,34 +18,53 @@ __all__ = (
 )
 
 
+def _resolve_clean_params(context):
+    params = context["params"]
+    return {
+        "delete_successful": params.get("delete_successful", DagCleanTaskArgs.model_fields["delete_successful"].default),
+        "delete_failed": params.get("delete_failed", DagCleanTaskArgs.model_fields["delete_failed"].default),
+        "mark_failed_as_successful": params.get("mark_failed_as_successful", DagCleanTaskArgs.model_fields["mark_failed_as_successful"].default),
+        "max_dagruns": params.get("max_dagruns", DagCleanTaskArgs.model_fields["max_dagruns"].default),
+        "days_to_keep": params.get("days_to_keep", DagCleanTaskArgs.model_fields["days_to_keep"].default),
+    }
+
+
+def _resolve_backend(context):
+    params = context["params"]
+    return {
+        "kind": params.get("backend") or "auto",
+        "connection_id": params.get("connection_id") or DagCleanTaskArgs.model_fields["connection_id"].default,
+        "mwaa_environment_name": params.get("mwaa_environment_name"),
+        "mwaa_region_name": params.get("mwaa_region_name"),
+    }
+
+
 def create_clean_dag_runs():
+    if _airflow_3():
+        # Airflow 3 tasks have no database access, use the REST API
+        def _clean_dag_runs(**context):
+            clean_dag_runs_api(backend=_resolve_backend(context), **_resolve_clean_params(context))
+
+        return _clean_dag_runs
+
     # Wrapped to avoid airflow imports
     from airflow.utils.session import provide_session
 
     @provide_session
     def _clean_dag_runs(session=None, **context):
-        params = context["params"]
-
-        # Get the configurable parameters
-        delete_successful = params.get("delete_successful", DagCleanTaskArgs.model_fields["delete_successful"].default)
-        delete_failed = params.get("delete_failed", DagCleanTaskArgs.model_fields["delete_failed"].default)
-        mark_failed_as_successful = params.get("mark_failed_as_successful", DagCleanTaskArgs.model_fields["mark_failed_as_successful"].default)
-        max_dagruns = params.get("max_dagruns", DagCleanTaskArgs.model_fields["max_dagruns"].default)
-        days_to_keep = params.get("days_to_keep", DagCleanTaskArgs.model_fields["days_to_keep"].default)
-
-        clean_dag_runs(
-            session=session,
-            delete_successful=delete_successful,
-            delete_failed=delete_failed,
-            mark_failed_as_successful=mark_failed_as_successful,
-            max_dagruns=max_dagruns,
-            days_to_keep=days_to_keep,
-        )
+        clean_dag_runs(session=session, **_resolve_clean_params(context))
 
     return _clean_dag_runs
 
 
 def create_clean_dags():
+    if _airflow_3():
+        # Airflow 3 tasks have no database access, use the REST API
+        def _clean_dags(**context):
+            clean_dags_api(backend=_resolve_backend(context))
+
+        return _clean_dags
+
     # Wrapped to avoid airflow imports
     from airflow.utils.session import provide_session
 
@@ -54,6 +76,14 @@ def create_clean_dags():
 
 
 def create_clean_dags_and_dag_runs():
+    if _airflow_3():
+
+        def _clean_dags_and_dag_runs(**context):
+            create_clean_dag_runs()(**context)
+            create_clean_dags()(**context)
+
+        return _clean_dags_and_dag_runs
+
     # Wrapped to avoid airflow imports
     from airflow.utils.session import provide_session
 
@@ -69,7 +99,17 @@ def create_clean_dags_and_dag_runs():
 
 def _move_clean_kwargs_to_params(kwargs):
     clean_params = {}
-    for key in ("delete_successful", "delete_failed", "mark_failed_as_successful", "max_dagruns", "days_to_keep"):
+    for key in (
+        "delete_successful",
+        "delete_failed",
+        "mark_failed_as_successful",
+        "max_dagruns",
+        "days_to_keep",
+        "backend",
+        "connection_id",
+        "mwaa_environment_name",
+        "mwaa_region_name",
+    ):
         if key in kwargs:
             clean_params[key] = kwargs.pop(key)
     if clean_params:
@@ -98,6 +138,10 @@ class DagCleanTaskArgs(TaskArgs):
     mark_failed_as_successful: bool | None = Field(default=False)
     max_dagruns: int | None = Field(default=10)
     days_to_keep: int | None = Field(default=10)
+    backend: Literal["auto", "airflow3", "mwaa"] | None = Field(default="auto", description="API backend used on Airflow 3")
+    connection_id: str | None = Field(default="airflow_laminar_api", description="Airflow connection with API credentials for the airflow3 backend")
+    mwaa_environment_name: str | None = Field(default=None, description="MWAA environment name for the mwaa backend")
+    mwaa_region_name: str | None = Field(default=None, description="AWS region of the MWAA environment")
 
 
 # Alias

--- a/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
+++ b/airflow_pydantic/tests/extras/balancer/test_pool_manager.py
@@ -183,3 +183,33 @@ def test_mwaa_backend_uses_iam_rest_api():
 
     boto3.client.assert_called_once_with("mwaa", region_name="us-east-1")
     boto_client.invoke_rest_api.assert_called_once_with(Name="environment", Path="/pools/pool", Method="GET")
+
+
+def test_mwaa_backend_passes_query_parameters_and_detects_environment(monkeypatch):
+    monkeypatch.setenv("AIRFLOW_ENV_NAME", "detected-environment")
+    boto_client = MagicMock()
+    boto_client.invoke_rest_api.return_value = {"RestApiStatusCode": 204}
+    boto3 = ModuleType("boto3")
+    boto3.client = MagicMock(return_value=boto_client)
+
+    with patch.dict(sys.modules, {"boto3": boto3}):
+        request = _mwaa_request({})
+        assert request("GET", "/dags", query={"limit": 100, "offset": 0}) is None
+
+    boto_client.invoke_rest_api.assert_called_once_with(
+        Name="detected-environment", Path="/dags", Method="GET", QueryParameters={"limit": 100, "offset": 0}
+    )
+
+
+def test_http_request_query_and_empty_response():
+    from airflow_pydantic.extras.balancer._pool_runtime import _http_request
+
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = b""
+
+    with patch("airflow_pydantic.extras.balancer._pool_runtime.urlopen", return_value=response) as open_url:
+        assert _http_request("http://api:8080", "DELETE", "/api/v2/dags/d1", query={"limit": 1}) is None
+
+    api_request = open_url.call_args.args[0]
+    assert api_request.full_url == "http://api:8080/api/v2/dags/d1?limit=1"
+    assert api_request.get_method() == "DELETE"

--- a/airflow_pydantic/tests/extras/common/test_airflow_functions.py
+++ b/airflow_pydantic/tests/extras/common/test_airflow_functions.py
@@ -1,7 +1,14 @@
+from datetime import datetime, timedelta
+from urllib.parse import unquote
+
 import pytest
+from pytz import UTC
 
 from airflow_pydantic import fail, pass_, skip
 from airflow_pydantic.airflow import AirflowFailException, AirflowSkipException
+from airflow_pydantic.extras.balancer import _pool_runtime
+from airflow_pydantic.extras.common import airflow_functions
+from airflow_pydantic.extras.common.airflow_functions import clean_dag_runs_api, clean_dags_api
 
 
 class TestCommon:
@@ -15,3 +22,152 @@ class TestCommon:
     def test_fail(self):
         with pytest.raises(AirflowFailException):
             fail()
+
+
+class FakeRequest:
+    def __init__(self, dags=None, dag_runs=None):
+        self.dags = dags or []
+        self.dag_runs = dag_runs or {}
+        self.deletes = []
+        self.patches = []
+        self.gets = []
+
+    def __call__(self, method, path, query=None, body=None, missing_ok=False):
+        path = unquote(path)
+        if method == "DELETE":
+            self.deletes.append(path)
+            return None
+        if method == "PATCH":
+            self.patches.append((path, body))
+            return None
+        self.gets.append((path, query))
+        limit = query["limit"]
+        offset = query["offset"]
+        if path.endswith("/dagRuns"):
+            dag_id = path.removeprefix("/dags/").removesuffix("/dagRuns")
+            runs = self.dag_runs.get(dag_id, [])
+            return {"dag_runs": runs[offset : offset + limit], "total_entries": len(runs)}
+        return {"dags": self.dags[offset : offset + limit], "total_entries": len(self.dags)}
+
+
+def _run(run_id, state, days_old):
+    date = (datetime.now(tz=UTC) - timedelta(days=days_old)).isoformat()
+    return {"dag_run_id": run_id, "state": state, "logical_date": date, "run_after": date}
+
+
+def _patch_api(monkeypatch, api):
+    monkeypatch.setattr(airflow_functions, "_create_api_request", lambda backend=None: api)
+
+
+class TestCleanAPI:
+    def test_deletes_old_runs_only(self, monkeypatch):
+        api = FakeRequest(
+            dags=[{"dag_id": "d1", "is_stale": False}],
+            dag_runs={"d1": [_run("old", "success", 20), _run("recent", "success", 1)]},
+        )
+        _patch_api(monkeypatch, api)
+        clean_dag_runs_api(delete_successful=True, delete_failed=True, mark_failed_as_successful=False, max_dagruns=10, days_to_keep=10)
+        assert api.deletes == ["/dags/d1/dagRuns/old"]
+        assert api.patches == []
+
+    def test_deletes_excess_runs(self, monkeypatch):
+        runs = [_run(f"r{i}", "success", days_old=5 - i) for i in range(5)]
+        api = FakeRequest(dags=[{"dag_id": "d1"}], dag_runs={"d1": runs})
+        _patch_api(monkeypatch, api)
+        clean_dag_runs_api(delete_successful=True, delete_failed=True, mark_failed_as_successful=False, max_dagruns=2, days_to_keep=10)
+        assert api.deletes == [f"/dags/d1/dagRuns/r{i}" for i in range(3)]
+
+    def test_respects_delete_successful_flag(self, monkeypatch):
+        api = FakeRequest(
+            dags=[{"dag_id": "d1"}],
+            dag_runs={"d1": [_run("old_success", "success", 20), _run("old_failed", "failed", 20)]},
+        )
+        _patch_api(monkeypatch, api)
+        clean_dag_runs_api(delete_successful=False, delete_failed=True, mark_failed_as_successful=False, max_dagruns=10, days_to_keep=10)
+        assert api.deletes == ["/dags/d1/dagRuns/old_failed"]
+
+    def test_skips_non_deletable_states(self, monkeypatch):
+        api = FakeRequest(
+            dags=[{"dag_id": "d1"}],
+            dag_runs={"d1": [_run("old_running", "running", 20), _run("recent", "success", 1)]},
+        )
+        _patch_api(monkeypatch, api)
+        clean_dag_runs_api(delete_successful=True, delete_failed=True, mark_failed_as_successful=False, max_dagruns=10, days_to_keep=10)
+        assert api.deletes == []
+
+    def test_marks_failed_as_successful(self, monkeypatch):
+        api = FakeRequest(
+            dags=[{"dag_id": "d1"}],
+            dag_runs={"d1": [_run("failed", "failed", 1), _run("success", "success", 1)]},
+        )
+        _patch_api(monkeypatch, api)
+        clean_dag_runs_api(delete_successful=True, delete_failed=True, mark_failed_as_successful=True, max_dagruns=10, days_to_keep=10)
+        assert api.deletes == []
+        assert api.patches == [("/dags/d1/dagRuns/failed", {"state": "success"})]
+
+    def test_paginates(self, monkeypatch):
+        api = FakeRequest(dags=[{"dag_id": f"d{i}"} for i in range(150)])
+        _patch_api(monkeypatch, api)
+        clean_dags_api()
+        dag_list_calls = [(path, query) for path, query in api.gets if path == "/dags"]
+        assert len(dag_list_calls) == 2
+        assert dag_list_calls[0][1] == {"limit": 100, "offset": 0, "exclude_stale": "false"}
+        assert dag_list_calls[1][1] == {"limit": 100, "offset": 100, "exclude_stale": "false"}
+
+    def test_clean_dags_deletes_stale_only(self, monkeypatch):
+        api = FakeRequest(dags=[{"dag_id": "live", "is_stale": False}, {"dag_id": "stale", "is_stale": True}])
+        _patch_api(monkeypatch, api)
+        clean_dags_api()
+        assert api.deletes == ["/dags/stale"]
+
+    def test_get_api_base_url(self, monkeypatch):
+        monkeypatch.delenv("AIRFLOW__API__BASE_URL", raising=False)
+        monkeypatch.setenv("AIRFLOW__CORE__EXECUTION_API_SERVER_URL", "http://apiserver:8080/execution/")
+        assert airflow_functions._get_api_base_url() == "http://apiserver:8080"
+        monkeypatch.setenv("AIRFLOW__API__BASE_URL", "http://other:8080/")
+        assert airflow_functions._get_api_base_url() == "http://other:8080"
+        assert airflow_functions._get_api_base_url("http://explicit:8080/") == "http://explicit:8080"
+
+
+class TestCreateAPIRequest:
+    def test_auto_detects_mwaa_from_environment(self, monkeypatch):
+        monkeypatch.setenv("AIRFLOW_ENV_NAME", "environment")
+        monkeypatch.setattr(_pool_runtime, "_mwaa_request", lambda backend: "mwaa-request")
+        assert airflow_functions._create_api_request() == "mwaa-request"
+
+    def test_explicit_mwaa_backend(self, monkeypatch):
+        monkeypatch.delenv("AIRFLOW_ENV_NAME", raising=False)
+        captured = {}
+
+        def mwaa_request(backend):
+            captured.update(backend)
+            return "mwaa-request"
+
+        monkeypatch.setattr(_pool_runtime, "_mwaa_request", mwaa_request)
+        assert airflow_functions._create_api_request({"kind": "mwaa", "mwaa_environment_name": "environment"}) == "mwaa-request"
+        assert captured["mwaa_environment_name"] == "environment"
+
+    def test_airflow3_uses_connection(self, monkeypatch):
+        monkeypatch.delenv("AIRFLOW_ENV_NAME", raising=False)
+        monkeypatch.setattr(_pool_runtime, "_airflow3_request", lambda backend: "connection-request")
+        assert airflow_functions._create_api_request() == "connection-request"
+
+    def test_airflow3_falls_back_to_environment_token(self, monkeypatch):
+        monkeypatch.delenv("AIRFLOW_ENV_NAME", raising=False)
+
+        def no_connection(backend):
+            raise ValueError("no connection")
+
+        monkeypatch.setattr(_pool_runtime, "_airflow3_request", no_connection)
+        monkeypatch.setattr(airflow_functions, "_get_api_base_url", lambda base_url=None: "http://test:8080")
+        monkeypatch.setattr(airflow_functions, "_get_api_token", lambda base_url, **kwargs: "test-token")
+
+        calls = []
+        monkeypatch.setattr(_pool_runtime, "_http_request", lambda *args, **kwargs: calls.append((args, kwargs)) or {"dags": []})
+
+        request = airflow_functions._create_api_request()
+        assert request("GET", "/dags", query={"limit": 1}) == {"dags": []}
+        args, kwargs = calls[0]
+        assert args == ("http://test:8080", "GET", "/api/v2/dags")
+        assert kwargs["query"] == {"limit": 1}
+        assert kwargs["token"] == "test-token"

--- a/airflow_pydantic/tests/extras/common/test_common_config.py
+++ b/airflow_pydantic/tests/extras/common/test_common_config.py
@@ -36,6 +36,17 @@ with DAG(
         "mark_failed_as_successful": Param(False, title="Mark Failed As Successful", description=None, type="boolean"),
         "max_dagruns": Param(10, title="Max Dagruns", description=None, type="integer"),
         "days_to_keep": Param(10, title="Days To Keep", description=None, type="integer"),
+        "backend": Param("auto", title="Backend", description="API backend used on Airflow 3", type="string"),
+        "connection_id": Param(
+            "airflow_laminar_api",
+            title="Connection Id",
+            description="Airflow connection with API credentials for the airflow3 backend",
+            type="string",
+        ),
+        "mwaa_environment_name": Param(
+            None, title="Mwaa Environment Name", description="MWAA environment name for the mwaa backend", type=["null", "string"]
+        ),
+        "mwaa_region_name": Param(None, title="Mwaa Region Name", description="AWS region of the MWAA environment", type=["null", "string"]),
     },
     dag_id="test_clean",
     default_args={},
@@ -80,6 +91,17 @@ with DAG(
         "mark_failed_as_successful": Param(False, title="Mark Failed As Successful", description=None, type="boolean"),
         "max_dagruns": Param(100, title="Max Dagruns", description=None, type="integer"),
         "days_to_keep": Param(60, title="Days To Keep", description=None, type="integer"),
+        "backend": Param("auto", title="Backend", description="API backend used on Airflow 3", type="string"),
+        "connection_id": Param(
+            "airflow_laminar_api",
+            title="Connection Id",
+            description="Airflow connection with API credentials for the airflow3 backend",
+            type="string",
+        ),
+        "mwaa_environment_name": Param(
+            None, title="Mwaa Environment Name", description="MWAA environment name for the mwaa backend", type=["null", "string"]
+        ),
+        "mwaa_region_name": Param(None, title="Mwaa Region Name", description="AWS region of the MWAA environment", type=["null", "string"]),
     },
     dag_id="test_clean",
     default_args={},
@@ -113,6 +135,17 @@ with DAG(
         "mark_failed_as_successful": Param(False, title="Mark Failed As Successful", description=None, type="boolean"),
         "max_dagruns": Param(50, title="Max Dagruns", description=None, type="integer"),
         "days_to_keep": Param(30, title="Days To Keep", description=None, type="integer"),
+        "backend": Param("auto", title="Backend", description="API backend used on Airflow 3", type="string"),
+        "connection_id": Param(
+            "airflow_laminar_api",
+            title="Connection Id",
+            description="Airflow connection with API credentials for the airflow3 backend",
+            type="string",
+        ),
+        "mwaa_environment_name": Param(
+            None, title="Mwaa Environment Name", description="MWAA environment name for the mwaa backend", type=["null", "string"]
+        ),
+        "mwaa_region_name": Param(None, title="Mwaa Region Name", description="AWS region of the MWAA environment", type=["null", "string"]),
     },
     dag_id="test_clean",
     default_args={},

--- a/airflow_pydantic/tests/extras/common/test_common_models.py
+++ b/airflow_pydantic/tests/extras/common/test_common_models.py
@@ -1,6 +1,7 @@
 import pytest
 
 from airflow_pydantic import DagClean
+from airflow_pydantic.migration import _airflow_3
 
 
 class TestModels:
@@ -12,3 +13,32 @@ class TestModels:
 
         d = DAG(dag_id="test_dag_clean")
         DagClean(task_id="test_clean_dags", dag=d)
+
+    @pytest.mark.skipif(not _airflow_3(), reason="Airflow 3 only")
+    def test_clean_callables_use_api_on_airflow_3(self, monkeypatch):
+        from airflow_pydantic.extras.common import clean
+
+        dag_run_calls = []
+        dag_calls = []
+        monkeypatch.setattr(clean, "clean_dag_runs_api", lambda **kwargs: dag_run_calls.append(kwargs))
+        monkeypatch.setattr(clean, "clean_dags_api", lambda **kwargs: dag_calls.append(kwargs))
+
+        clean.create_clean_dags_and_dag_runs()(params={"days_to_keep": 3, "mwaa_environment_name": "environment"})
+
+        backend = {
+            "kind": "auto",
+            "connection_id": "airflow_laminar_api",
+            "mwaa_environment_name": "environment",
+            "mwaa_region_name": None,
+        }
+        assert dag_run_calls == [
+            {
+                "delete_successful": True,
+                "delete_failed": True,
+                "mark_failed_as_successful": False,
+                "max_dagruns": 10,
+                "days_to_keep": 3,
+                "backend": backend,
+            }
+        ]
+        assert dag_calls == [{"backend": backend}]


### PR DESCRIPTION
## Description

`DagClean` / `DagRunClean` relied on direct metadata database access, which tasks no longer have on Airflow 3. On Airflow 3 they now use the REST API through the same backend selection as the balancer pool runtime (`auto` / `airflow3` / `mwaa`):

- **airflow3**: credentials from the `airflow_laminar_api` Airflow connection (fetched via the task execution API, no DB needed), falling back to environment variables and the `/auth/token` endpoint
- **mwaa**: boto3 `invoke_rest_api` using the worker's IAM execution role (requires `airflow:InvokeRestApi`), auto-detected from the `AIRFLOW_ENV_NAME` environment variable MWAA sets
- Airflow 2 keeps the existing ORM path unchanged

The shared transport in `_pool_runtime` gained query-parameter support, empty/204 response handling, and MWAA environment auto-detection, all backward compatible with the pool reconciliation call sites.

Behavioral notes on Airflow 3:

- `clean_dags` deletes DAGs the dag processor marked stale (`is_stale`) rather than checking file existence locally, which is meaningless on a remote worker
- DAG runs are ordered by `logical_date` (falling back to `run_after`) since `execution_date` no longer exists
- Runs in non-deletable states (e.g. running) are skipped; the API returns 409 for them
- `DagCleanTaskArgs` gains `backend`, `connection_id`, `mwaa_environment_name`, and `mwaa_region_name`, mirroring `PoolManagerConfiguration`

## Type of Change

- [x] New feature

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [ ] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)
